### PR TITLE
docs: update grafana documentation with parameters for cm

### DIFF
--- a/docs/services/grafana.md
+++ b/docs/services/grafana.md
@@ -4,6 +4,12 @@ To be able to create Grafana annotation with argocd-notifications you have to cr
 
 ![sample](https://user-images.githubusercontent.com/18019529/112024976-0f106080-8b78-11eb-9658-7663305899be.png)
 
+Available parameters :
+
+* `apiURL` - the server url, e.g. https://grafana.example.com
+* `apiKey` - the API key for the serviceaccount
+* `insecureSkipVerify` - optional bool, true or false
+
 1. Login to your Grafana instance as `admin`
 2. On the left menu, go to Configuration / API Keys
 3. Click "Add API Key" 


### PR DESCRIPTION
Adding possible parameters for grafana service CM. Especially adding insecureSkipVerify. Adding the CA for grafana in the argocd-tls-certs-cm confiMap doesn't help with TLS x509 cert errors (openshift-gitops operator argo 2.6.7)